### PR TITLE
Update rule

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-workstream (1.0.0)
+    rubocop-workstream (1.0.4)
       rubocop (~> 1.37)
 
 GEM
@@ -26,7 +26,7 @@ GEM
       rubocop-ast (>= 1.23.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.23.0)
+    rubocop-ast (1.24.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.3.0)

--- a/README.md
+++ b/README.md
@@ -913,21 +913,6 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
   STATES = ["draft", "open", "closed"]
   ~~~
 
-* Append a trailing comma in multi-line collection literals.
-
-  ~~~ ruby
-  # bad
-  {
-    foo: :bar,
-    baz: :toto
-  }
-
-  # good
-  {
-    foo: :bar,
-    baz: :toto,
-  }
-  ~~~
 
 * When accessing the first or last element from an array, prefer `first` or
   `last` over `[0]` or `[-1]`.

--- a/rubocop-workstream.gemspec
+++ b/rubocop-workstream.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "rubocop-workstream"
-  s.version     = "1.0.0"
+  s.version     = "1.0.4"
   s.summary     = "Workstream's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Workstream's style guide for Ruby."

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -718,15 +718,6 @@ Style/SymbolArray:
 Style/TrailingBodyOnMethodDefinition:
   Enabled: false
 
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-
 Style/TrailingMethodEndStatement:
   Enabled: false
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -50,6 +50,8 @@ Layout/LineEndStringConcatenationIndentation:
   EnforcedStyle: indented
 
 Layout/LineLength:
+  Exclude:
+    - 'spec/**/*'
   IgnoreCopDirectives: false
   AllowedPatterns:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"


### PR DESCRIPTION
- [remove trailing comma enforced style check](https://github.com/helloworld1812/ruby-style-guide/pull/2/commits/0f4fe391ed0a27b083ebb110a75a7f3ca84b2b18)
- [exclude spec directory for rule LineLength](https://github.com/helloworld1812/ruby-style-guide/pull/2/commits/a7e02c8ae37eedc35f52038758f3f0614a0d033b)
- [bump to 1.0.4](https://github.com/helloworld1812/ruby-style-guide/pull/2/commits/4a9dbf676ea99c8be4fd3500796d5583fde8f9f9)