### PR TITLE
Fix lint error on Rails.env.staging?

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -348,6 +348,13 @@ Naming/RescuedExceptionsVariableName:
 Naming/VariableNumber:
   Enabled: false
 
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - develop
+    - test
+    - staging
+
 Security/CompoundHash:
   Enabled: false
 


### PR DESCRIPTION
Seems rubocop will not recognize our environments under `environments` folder. Add this to fix lint error of `Rails.env.staging?` & `Rails.env.develop?`

https://github.com/rubocop/rubocop/issues/4956#issuecomment-340235408