### PR TITLE
disable a few style rules to support both rubocop's default and shopify's

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -22,19 +22,19 @@ Layout/ArgumentAlignment:
   Enabled: false
 
 Layout/CaseIndentation:
-  EnforcedStyle: end
+  Enabled: false
 
 Layout/EndAlignment:
-  EnforcedStyleAlignWith: variable
+  Enabled: false
 
 Layout/FirstArgumentIndentation:
   Enabled: false
 
 Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
+  Enabled: false
 
 Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
+  Enabled: false
 
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit
@@ -46,8 +46,7 @@ Layout/LineContinuationSpacing:
   Enabled: false
 
 Layout/LineEndStringConcatenationIndentation:
-  Enabled: true
-  EnforcedStyle: indented
+  Enabled: false
 
 Layout/LineLength:
   Exclude:
@@ -57,14 +56,13 @@ Layout/LineLength:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
 
 Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-  IndentationWidth: 2
+  Enabled: false
 
 Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
+  Enabled: false
 
 Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
+  Enabled: false
 
 Layout/SpaceBeforeBrackets:
   Enabled: true
@@ -375,10 +373,10 @@ Style/AccessorGrouping:
   Enabled: false
 
 Style/Alias:
-  EnforcedStyle: prefer_alias_method
+  Enabled: false
 
 Style/AndOr:
-  EnforcedStyle: always
+  Enabled: false
 
 Style/ArgumentsForwarding:
   Enabled: false
@@ -397,8 +395,7 @@ Style/ClassEqualityComparison:
   Enabled: false
 
 Style/ClassMethodsDefinitions:
-  EnforcedStyle: self_class
-  Enabled: true
+  Enabled: false
 
 Style/CollectionCompact:
   Enabled: false
@@ -410,7 +407,7 @@ Style/CombinableLoops:
   Enabled: false
 
 Style/CommandLiteral:
-  EnforcedStyle: percent_x
+  Enabled: false
 
 Style/CommentedKeyword:
   Enabled: false
@@ -561,7 +558,7 @@ Style/MixinUsage:
   Enabled: false
 
 Style/ModuleFunction:
-  EnforcedStyle: extend_self
+  Enabled: false
 
 Style/MultilineBlockChain:
   Enabled: false
@@ -669,7 +666,7 @@ Style/RedundantStringEscape:
   Enabled: true
 
 Style/RegexpLiteral:
-  EnforcedStyle: mixed
+  Enabled: false
 
 Style/RescueStandardError:
   Enabled: false
@@ -699,7 +696,7 @@ Style/StringLiterals:
   Enabled: false
 
 Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
+  Enabled: false
 
 Style/StructInheritance:
   Enabled: false
@@ -708,7 +705,7 @@ Style/SwapValues:
   Enabled: false
 
 Style/SymbolArray:
-  EnforcedStyle: brackets
+  Enabled: false
 
 Style/TrailingBodyOnMethodDefinition:
   Enabled: false
@@ -723,7 +720,7 @@ Style/UnpackFirst:
   Enabled: false
 
 Style/WordArray:
-  EnforcedStyle: brackets
+  Enabled: false
 
 Style/YodaCondition:
   Enabled: false


### PR DESCRIPTION
```ruby
require 'net/http'
require 'uri'

rubocop = YAML.safe_load(Net::HTTP.get(URI.parse('https://raw.githubusercontent.com/rubocop/rubocop/master/config/default.yml')))
ws = YAML.safe_load(Net::HTTP.get(URI.parse('https://raw.githubusercontent.com/helloworld1812/ruby-style-guide/master/rubocop.yml')))

ws.each do |key, value|
  next unless key.include?('/')
  next if false === key['Enabled']

  style_key = value.keys.find { |k| k.start_with?('EnforcedStyle') }
  next unless style_key
  next if rubocop[key][style_key] == value[style_key]

  puts "#{key}: #{style_key} = #{value[style_key]} - #{rubocop[key][style_key]} / #{rubocop[key]['Enabled']}"
end
```